### PR TITLE
Fix Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,17 +9,15 @@ RUN apt-get update -y && apt-get install -y speedtest-cli cron
 
 # clone repo
 WORKDIR /var/www/html
-COPY . /var/www/html/BetterThanNothingWebInterface
-# ...also put here, because that's where scripts are expected
-RUN ln -s /var/www/html/BetterThanNothingWebInterface /var/www/html/btnwi
+COPY . /var/www/html
 
 # Snag favicon from Starlink
 RUN curl https://www.starlink.com/assets/favicon.ico > favicon.ico
 
 # schedule speedtest
-RUN echo "*/15 * * * * /usr/local/bin/php /var/www/html/BetterThanNothingWebInterface/scripts/cron/php/speedtest.cron.php" >> /var/spool/cron/crontabs/root
+RUN echo "*/15 * * * * /usr/local/bin/php /var/www/html/scripts/cron/php/speedtest.cron.php" >> /var/spool/cron/crontabs/root
 RUN chmod 600 /var/spool/cron/crontabs/root
 RUN chown root.crontab /var/spool/cron/crontabs/root
 
 # start apache and run update scripts
-CMD /etc/init.d/apache2 start && cron && /var/www/html/BetterThanNothingWebInterface/scripts/binbash/starlink.history.update.sh & /var/www/html/BetterThanNothingWebInterface/scripts/binbash/starlink.update.sh
+CMD /etc/init.d/apache2 start && cron && /var/www/html/scripts/binbash/starlink.history.update.sh & /var/www/html/scripts/binbash/starlink.update.sh

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -40,4 +40,4 @@ If you don't want to figure that stuff out and are comfortable with docker, you 
 docker-compose build && docker-compose up -d
 ```
 
-Once built and running, you can view the status page at [http://localhost/BetterThanNothingWebInterface](http://localhost/BetterThanNothingWebInterface)
+Once built and running, you can view the status page at [http://localhost/](http://localhost/)

--- a/scripts/binbash/starlink.history.update.sh
+++ b/scripts/binbash/starlink.history.update.sh
@@ -1,3 +1,5 @@
 #/bin/bash
 
-while true ; do php /var/www/html/btnwi/scripts/cron/php/dishy.history.cron.php & printf . & sleep 5; done
+require(dirname(__FILE__).'/../../../config.inc.php');
+
+while true ; do php $_CONFIG["path"]/scripts/cron/php/dishy.history.cron.php & printf . & sleep 5; done

--- a/scripts/binbash/starlink.history.update.sh
+++ b/scripts/binbash/starlink.history.update.sh
@@ -1,5 +1,3 @@
 #/bin/bash
 
-require(dirname(__FILE__).'/../../../config.inc.php');
-
-while true ; do php $_CONFIG["path"]/scripts/cron/php/dishy.history.cron.php & printf . & sleep 5; done
+while true ; do php /var/www/html/scripts/cron/php/dishy.history.cron.php & printf . & sleep 5; done


### PR DESCRIPTION
This fixes the Docker file and makes it work out-of-the-box.

This may also fix an issue where the bash is referencing an old path in `scripts/binbash/starlink.history.update.sh` which probably affects the non-docker version as well.
#10 